### PR TITLE
Make composer installation idempotent

### DIFF
--- a/puppet/manifests/default.pp
+++ b/puppet/manifests/default.pp
@@ -188,6 +188,7 @@ class php-setup {
 class composer {
     exec { 'install composer php dependency management':
         command => 'curl -s http://getcomposer.org/installer | php -- --install-dir=/usr/bin && mv /usr/bin/composer.phar /usr/bin/composer',
+        creates => '/usr/bin/composer',
         require => [Package['php5-cli'], Package['curl']],
     }
 }


### PR DESCRIPTION
This prevents composer from ran always if it's already installed.
