### PR TITLE
Fixed 502 bad gateway bug (issue #13)

### DIFF
--- a/files/php/fpm/pool.d/www.conf
+++ b/files/php/fpm/pool.d/www.conf
@@ -41,9 +41,9 @@ listen = /var/run/php5-fpm.sock
 ; BSD-derived systems allow connections regardless of permissions. 
 ; Default Values: user and group are set as the running user
 ;                 mode is set to 0666
-;listen.owner = www-data
-;listen.group = www-data
-;listen.mode = 0666
+listen.owner = www-data
+listen.group = www-data
+listen.mode = 0666
  
 ; List of ipv4 addresses of FastCGI clients which are allowed to connect.
 ; Equivalent to the FCGI_WEB_SERVER_ADDRS environment variable in the original


### PR DESCRIPTION
This fixes the bug that is being discussed in the issue #13 - the listen owner and group have to be set to www-data (the nginx user) - now there is no more "502 Bad Gateway" error on every request.
