### PR TITLE
Fix nodeJs error - failed to fetch from registry

### DIFF
--- a/puppet/manifests/default.pp
+++ b/puppet/manifests/default.pp
@@ -18,7 +18,11 @@ class dev-packages {
         ensure => "installed",
         require => Exec['apt-get update'],
     }
-
+	exec { 'enable ability to install npm packages':
+		command => 'npm config set registry http://registry.npmjs.org/',
+		require => Package["npm"],
+	}
+	
     exec { 'install less using npm':
         command => 'npm install less -g',
         require => Package["npm"],


### PR DESCRIPTION
As resolved by @jgreenman in
https://github.com/irmantas/symfony2-vagrant/issues/8

It seems to be a common issue for NodeJs